### PR TITLE
Kwargs request

### DIFF
--- a/collegamento/client_server/client.py
+++ b/collegamento/client_server/client.py
@@ -110,13 +110,9 @@ class Client:
 
         return id
 
-    def request(
-        self,
-        request_details: dict,
-    ) -> None:
+    def request(self, command: str, **kwargs) -> None:
         """Sends the main process a request of type command with given kwargs - external API"""
 
-        command = request_details["command"]
         if command not in self.commands:
             raise CollegamentoError(
                 f"Command {command} not in builtin commands. Those are {self.commands}!"
@@ -129,7 +125,7 @@ class Client:
             "type": "request",
             "command": command,
         }
-        final_request.update(request_details)
+        final_request.update(**kwargs)
 
         if self.commands[command][1]:
             self.current_ids[id] = command

--- a/collegamento/files_variant.py
+++ b/collegamento/files_variant.py
@@ -52,18 +52,15 @@ class FileClient(Client):
         for file, data in files_copy.items():
             self.update_file(file, data)
 
-    def request(
-        self,
-        request_details: dict,
-    ) -> None:
-        if "file" in request_details:
-            file = request_details["file"]
+    def request(self, command: str, **kwargs) -> None:
+        if "file" in kwargs:
+            file = kwargs["file"]
             if file not in self.files:
                 raise CollegamentoError(
                     f"File {file} not in files! Files are {self.files.keys()}"
                 )
 
-        super().request(request_details)
+        super().request(command, **kwargs)
 
     def update_file(self, file: str, current_state: str) -> None:
         """Updates files in the system - external API"""
@@ -77,7 +74,7 @@ class FileClient(Client):
             "contents": self.files[file],
         }
 
-        super().request(file_notification)
+        super().request(**file_notification)
 
     def remove_file(self, file: str) -> None:
         """Removes a file from the main_server - external API"""
@@ -92,7 +89,7 @@ class FileClient(Client):
             "remove": True,
         }
 
-        super().request(file_notification)
+        super().request(**file_notification)
 
 
 class FileServer(Server):

--- a/docs/source/classes.rst
+++ b/docs/source/classes.rst
@@ -30,7 +30,7 @@ The ``Response`` class is what is returned by the "ref:`Client Overview` or one 
 
 The ``Client`` class can do:
 
-- ``Client.request(request_details: dict)`` (all details in request_details are specific to the command in the request_details)
+- ``Client.request(command: str, **kwargs)``
 - ``Client.add_command(name: str, command: USER_FUNCTION, multiple_requests: bool = False)`` (adds the function with the name provided that takes input of :ref:`Request Overview` and returns anything)
 - ``Client.get_response(command: str) -> Response | list[Response] | None`` (returns a list of ``Response``'s if the command allows multiple requests otherwise a single ``Response`` if there is were any responses ohterwise ``None``)
 - ``Client.kill_IPC()`` (kills the IPC server)
@@ -43,6 +43,8 @@ When using the ``Client`` class you give the commands as a dict. Below are the w
 By default ``Collegamento`` assumes you only want the newest request but chooses to still give the option to make multiple requests. For ``.get_response()`` the output changes based on how this was specified by giving ``None`` if there was no response, ``Response`` if the command only allows the newest request, and ``list[Response]`` if it allows multiple regardless of how many times you made a request for it.
 
 Note that because of the way that the commands are handed to the ``Server`` and run, they can actually modify its attributes and theoretically even the functions the ``Server`` runs. This high flexibility also requires the user to ensure that they properly manage any attributes they mess with.
+
+When it comes to requesting the server to run a command, you give the command as the first argument and all subsequent args for the function the ``Server`` calls are given as kwargs that are passed on.
 
 .. _Server Overview:
 

--- a/docs/source/example-usage.rst
+++ b/docs/source/example-usage.rst
@@ -22,7 +22,7 @@ Now that you have ``Collegamento`` installed, let's try running a simple example
         # like so: {"test": (foo, True)} (using (foo, False)) is the default (only newest request)
         context = Client({"test": foo})
 
-        context.request({"command": "test"})
+        context.request("test")
 
         sleep(1)
 

--- a/docs/source/examples/class_example.rst
+++ b/docs/source/examples/class_example.rst
@@ -19,7 +19,7 @@ Class Example
             self.context.update_file("user_file", new_contents)
     
         def request_split(self) -> None:
-            self.context.request({"command": "MyClientFunc", "file": "user_file"})
+            self.context.request("MyClientFunc", file="user_file")
     
         def check_split(self) -> list[str] | None:
             output = self.context.get_response("MyClientFunc")

--- a/docs/source/examples/file_example.rst
+++ b/docs/source/examples/file_example.rst
@@ -19,7 +19,7 @@ File Example
     
         context.update_file("test", "test contents")
         sleep(1)
-        context.request({"command": "test", "file": "test"})
+        context.request("test", file="test")
     
         sleep(1)
     

--- a/docs/source/examples/simple_example.rst
+++ b/docs/source/examples/simple_example.rst
@@ -20,7 +20,7 @@ Simple Example
         # like so: {"test": (foo, True)} (using (foo, False)) is the default (only newest request)
         context = Client({"test": foo})
     
-        context.request({"command": "test"})
+        context.request("test")
     
         sleep(1)
     

--- a/examples/class_example.py
+++ b/examples/class_example.py
@@ -13,7 +13,7 @@ class MyClient:
         self.context.update_file("user_file", new_contents)
 
     def request_split(self) -> None:
-        self.context.request({"command": "MyClientFunc", "file": "user_file"})
+        self.context.request("MyClientFunc", file="user_file")
 
     def check_split(self) -> list[str] | None:
         output = self.context.get_response("MyClientFunc")

--- a/examples/file_example.py
+++ b/examples/file_example.py
@@ -13,7 +13,7 @@ def main():
 
     context.update_file("test", "test contents")
     sleep(1)
-    context.request({"command": "test", "file": "test"})
+    context.request("test", file="test")
 
     sleep(1)
 

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -14,7 +14,7 @@ def main():
     # like so: {"test": (foo, True)} (using (foo, False)) is the default (only newest request)
     context = Client({"test": foo})
 
-    context.request({"command": "test"})
+    context.request("test")
 
     sleep(1)
 

--- a/tests/test_file_variant.py
+++ b/tests/test_file_variant.py
@@ -17,7 +17,7 @@ def test_file_variants():
 
     context.update_file("test", "test contents")
     context.update_file("test2", "test contents2")
-    context.request({"command": "test"})
+    context.request("test")
 
     sleep(1)
 
@@ -26,8 +26,8 @@ def test_file_variants():
     assert output["result"] is True  # noqa: E712 # type: ignore
 
     context.add_command("test1", split_str, True)
-    context.request({"command": "test1", "file": "test"})
-    context.request({"command": "test1", "file": "test2"})
+    context.request("test1", file="test")
+    context.request("test1", file="test2")
 
     sleep(1)
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -11,17 +11,15 @@ def test_normal_client():
     Client({"foo": foo})
     x = Client({"foo": (foo, True), "foo2": foo})
 
-    x.request({"command": "foo"})
-    x.request({"command": "foo"})
-    x.request({"command": "foo2"})
-    x.request(
-        {"command": "foo2"}
-    )  # If you see six "Foo called"'s, thats bad news bears
+    x.request("foo")
+    x.request("foo")
+    x.request("foo2")
+    x.request("foo2")  # If you see six "Foo called"'s, thats bad news bears
     x.add_command("foo3", foo)
-    x.request({"command": "foo3"})
+    x.request("foo3")
     x.add_command("foo4", foo, True)
-    x.request({"command": "foo4"})
-    x.request({"command": "foo4"})
+    x.request("foo4")
+    x.request("foo4")
 
     sleep(1)
 
@@ -44,7 +42,7 @@ def test_normal_client():
     assert x.all_ids == []
 
     Client()
-    Client({"foo": foo}).request({"command": "foo"})
+    Client({"foo": foo}).request("foo")
     Client().kill_IPC()
     Client().create_server()
 


### PR DESCRIPTION
Fixes #10.

To do:
 - [x] Use keyword arguments instead of a dict for requests

Current changes in PR:
 - Update Client/Server
 - Update FileClient/FileServer
 - Update docs
 - Update examples
 - Update tests